### PR TITLE
feat(autocropper): pass status from autocropper request back to webapp

### DIFF
--- a/app/handlers/autocropper.py
+++ b/app/handlers/autocropper.py
@@ -252,12 +252,13 @@ class AutoCropperHandler(BaseHandler):
         }
 
         response = requests.request("POST", url, headers=headers, data=payload, files=files)
+        response_status_code = response.status_code
+        response_json = response.json()
+
+        logging.info("Response from %s:", url)
+        logging.info("Status code: %s", response_status_code)
+        logging.info("Response json: %s", response_json)
 
         #return the response from the api
-        self.set_status(HTTPStatus.OK)
-        self.finish(self.json_encode({'status': 'success', 'data': response.json()}))
-
-
-
-
-
+        self.set_status(response_status_code)
+        self.finish(self.json_encode({'data': response_json}))


### PR DESCRIPTION
https://shihlee.atlassian.net/browse/LG-18

Prior to this PR, when the autocropper service returns a 500, linc-api passes back a 200 response to linc-webapp, linc-webapp tries to access properties that aren't in the response, and the app hangs here:

<img width="933" alt="image" src="https://github.com/linc-lion/linc-api/assets/16931750/1b5b3591-5826-464e-aa1a-a863a981c532">

If this PR is merged, autocropper passes along the 500 status and the user sees that an error occurred, after which the app does not hang:

<img width="1184" alt="image" src="https://github.com/linc-lion/linc-api/assets/16931750/2968a9a3-55fa-43a5-8968-d144b4011ae2">

This PR also makes some logging info in linc-api more accessible to the developer by sharing some response info in linc-api logging. This is redundant, since there's already logging in the browser console, but still seems valuable. Prior to this PR, for success, the evidence you get is:

```
10:53:42 AM web.1 |  [I 240206 10:53:42 web:2063] 200 POST /autocropper (127.0.0.1) 6816.99ms
```

For failure (this doesn't indicate that it failed):

```
10:55:03 AM web.1 |  [I 240206 10:55:03 web:2063] 200 POST /autocropper (127.0.0.1) 585.79ms
```

If this PR is merged, there's additional logged output for success:

```
10:19:54 AM web.1 |  [I 240206 10:19:54 autocropper:258] Response from http://linc-detector-api-env.eba-fn6zvvit.us-east-1.elasticbeanstalk.com/v1/annotate?vert_size=500:
10:19:54 AM web.1 |  [I 240206 10:19:54 autocropper:259] Status code: 200
10:19:54 AM web.1 |  [I 240206 10:19:54 autocropper:260] Response json: {'bounding_box_coords': {'cv-dl': [386.4779052734375, 302.6907653808594, 3024.28125, 2416.797119140625], 'ear-dl-l': [2144.302978515625, 429.1683349609375, 2952.106689453125, 1417.276123046875], 'ear-dl-r': [438.6786804199219, 271.6875305175781, 1113.8807373046875, 1234.2685546875], 'eye-dl-l': [1407.7713623046875, 1380.7183837890625, 1913.8704833984375, 1810.5247802734375], 'eye-dl-r': [664.96630859375, 1246.7122802734375, 977.3242797851562, 15
10:19:54 AM web.1 |  >  80.196044921875]}, 'input_image': 'static/uploads/1707243582231_lion_success.jpeg'}
```

For failure:

```
10:21:23 AM web.1 |  [I 240206 10:21:23 autocropper:258] Response from http://linc-detector-api-env.eba-fn6zvvit.us-east-1.elasticbeanstalk.com/v1/annotate?vert_size=500:
10:21:23 AM web.1 |  [I 240206 10:21:23 autocropper:259] Status code: 500
10:21:23 AM web.1 |  [I 240206 10:21:23 autocropper:260] Response json: {'error': "An error occurred: cannot identify image file 'static/uploads/1707243679554_not_a_real_image.jpg'"}
```