### PR TITLE
fix: Adds heroku api key

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HEROKU_APP_NAME: ${{ github.event.inputs.deploy_env == 'prod' && 'linc-api' || 'linc-api-staging' }}
+      HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
     steps:
       - name: Check if deploying to prod from non-main branch
         if: ${{ github.event.inputs.deploy_env == 'prod' && github.ref != 'refs/heads/main' }}


### PR DESCRIPTION
Resolves heroku: Press any key to open up the browser to login or q to exit: fatal: 'heroku' does not appear to be a git repository.