### PR TITLE
fix: update one with $set

### DIFF
--- a/app/handlers/animals.py
+++ b/app/handlers/animals.py
@@ -453,7 +453,7 @@ class AnimalsHandler(BaseHandler):
                     # the object is valid, so try to save
                     try:
                         updated = await self.Animals.update_one(
-                            {'_id': updid}, animals.to_native())
+                            {'_id': updid}, {'$set': animals.to_native()})
                         info(updated)
                         output = updobj
                         output['obj_id'] = str(updid)

--- a/app/handlers/images.py
+++ b/app/handlers/images.py
@@ -380,7 +380,7 @@ class ImagesHandler(BaseHandler, ProcessMixin):
                     # the object is valid, so try to save
                     try:
                         updobj['_id'] = objupdid
-                        saved = await self.Images.update_one(query, updobj)
+                        saved = await self.Images.update_one(query, {'$set': updobj})
                         info(saved)
                         # Ok, data saved so operate s3
                         # Copy the image to the new imageset

--- a/app/handlers/images.py
+++ b/app/handlers/images.py
@@ -379,7 +379,6 @@ class ImagesHandler(BaseHandler, ProcessMixin):
                     updobj = updobj.to_native()
                     # the object is valid, so try to save
                     try:
-                        updobj['_id'] = objupdid
                         saved = await self.Images.update_one(query, {'$set': updobj})
                         info(saved)
                         # Ok, data saved so operate s3
@@ -387,7 +386,6 @@ class ImagesHandler(BaseHandler, ProcessMixin):
                         # Copy the full for backup
                         output = updobj
                         output['obj_id'] = str(objupdid)
-                        del output['_id']
                         # Change iid to id in the output
                         self.switch_iid(output)
 

--- a/app/handlers/users.py
+++ b/app/handlers/users.py
@@ -209,7 +209,7 @@ class UsersHandler(BaseHandler):
                     try:
                         updobj = updobj.to_native()
                         updobj['_id'] = updid
-                        saved = await self.Users.update_one({'_id': updid}, updobj)
+                        saved = await self.Users.update_one({'_id': updid}, {'$set': updobj})
                         info(saved)
                         output = updobj
                         output['obj_id'] = str(updid)

--- a/app/handlers/users.py
+++ b/app/handlers/users.py
@@ -208,12 +208,10 @@ class UsersHandler(BaseHandler):
                     # the object is valid, so try to save
                     try:
                         updobj = updobj.to_native()
-                        updobj['_id'] = updid
                         saved = await self.Users.update_one({'_id': updid}, {'$set': updobj})
                         info(saved)
                         output = updobj
                         output['obj_id'] = str(updid)
-                        del output['_id']
                         # Change iid to id in the output
                         self.switch_iid(output)
                         del output['encrypted_password']

--- a/app/lib/db.py
+++ b/app/lib/db.py
@@ -72,7 +72,6 @@ class DBMethods:
             # the object is valid, so try to save
             try:
                 updobj = updobj.to_native()
-                updobj['_id'] = updid
                 saved = await self.Users.update_one({'_id': updid}, {'$set': updobj})
                 info(saved)
                 resp = [200, 'Password changed successfully.']

--- a/app/lib/db.py
+++ b/app/lib/db.py
@@ -73,7 +73,7 @@ class DBMethods:
             try:
                 updobj = updobj.to_native()
                 updobj['_id'] = updid
-                saved = await self.Users.update_one({'_id': updid}, updobj)
+                saved = await self.Users.update_one({'_id': updid}, {'$set': updobj})
                 info(saved)
                 resp = [200, 'Password changed successfully.']
             except Exception as e:


### PR DESCRIPTION
A few of our update_one calls differed from the others in that they didn't have a "$set" key, which is needed by PyMongo--the update object needs to specify an update action.

I have verified locally that, without this PR, changing and image tag results in an error, and after this PR it succeeds.

Here's an example from the previous big python 3.10 PR where there was no problem because the old `.update` command was already specifying $set:
https://github.com/linc-lion/linc-api/blob/4cb3f28e5bd438668f808af03c354011cb97775d/app/handlers/animals_relatives.py#L178-L180

Most of them are like this--they were specified before, so the update --> update_one (or update_many) caused no problem.

Here's an example of one of the four problematic ones:

https://github.com/linc-lion/linc-api/blob/4cb3f28e5bd438668f808af03c354011cb97775d/app/handlers/images.py#L383

The previous .update method didn't include $set, and it looks like old pymongo update was ok with this--it was possible to use $set (new, future proof way), or if there was no included database operation command, seems like it would just replace the existing object. Couldn't find full receipts for this, but I'm ok with it given that the problem is fixed, and prior to this change we're missing the $set key that we know is required.